### PR TITLE
ensure students go home before accessing .bashrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ code .
 
 ## Adding A Flatiron Customization To Your Terminal
 
-Start out by making a backup for your `.bashrc`
+Start out by ensuring you're back in the Linux home directory, with `cd ~` or just `cd`.
+
+Then, make a backup for your `.bashrc`
 
 ```
 mv .bashrc .bashrc.bak


### PR DESCRIPTION
If students are following step-by-step (which they should be...) the previous section leaves them on the Windows side.  BTW who's the authority here these days?  ;p 