### PR TITLE
Update WSL instructions for OAuth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ Note: if you get an error at this step, see FAQ below.
   gem install learn-co
   ```
   
-  - In your browser, navigate to learn.co/your_github_username
+  - In your browser:
+    - If you have connected your Github account to your Learn account, navigate to learn.co/your_github_username
+    - If you have not connected your Github account: Go to [your profile](https://learn.co/account/profile) > Learn Settings > Public Profile. Click on the link under **Username**
   - At the bottom of the page, you should see text that says `OAuth Token:` followed by a token. Copy the token, and then go back to your WSL terminal
   - Type:
 


### PR DESCRIPTION
We're currently running a course with learn.co and a number of students have been tripped over this step because it presumes that a Github is connected to the Learn account, but that's not necessarily the case.

Also see: https://github.com/learn-co-curriculum/linux-env-setup/pull/12